### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/simple-screen.el
+++ b/simple-screen.el
@@ -45,6 +45,8 @@
 (defvar simple-screen-current-index 0)
 (defvar simple-screen-mode-line "")
 
+(defvar simple-screen-map nil
+  "Prefix keymap for simple-screen commands.")
 (define-prefix-command 'simple-screen-map)
 (global-set-key (kbd "C-z") 'simple-screen-map)
 (define-key simple-screen-map "w" 'simple-screen-show-screen)


### PR DESCRIPTION
I got following error when byte-compiling.

```
Entering directory `/home/syohei/tmp/simple-screen/'
simple-screen.el:50:13:Warning: reference to free variable `simple-screen-map'
```
